### PR TITLE
Addressing feedback

### DIFF
--- a/contracts/bidding/Cargo.toml
+++ b/contracts/bidding/Cargo.toml
@@ -17,7 +17,6 @@ thiserror = "1"
 schemars = "0.8.1"
 cw-utils = "2.0.0"
 cosmwasm-schema = "1.1.4"
-rand = "0.8"
 
 [dev-dependencies]
 cw-multi-test = "2.0.1"

--- a/contracts/bidding/src/contract.rs
+++ b/contracts/bidding/src/contract.rs
@@ -5,13 +5,12 @@ use cosmwasm_std::{
     coins, to_json_binary, Addr, BankMsg, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response,
     StdResult,
 };
-use rand::Rng;
 
 pub type Result<T> = std::result::Result<T, ContractError>;
 
 const CRANK_MAX_BID_ITEMS: u32 = 3;
 const DENOM: &'static str = "eth";
-const LIMIT: u32 = 10;
+const PAGINATION_LIMIT: u32 = 10;
 
 pub fn instantiate(
     deps: DepsMut,
@@ -20,10 +19,6 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     ADMIN.save(deps.storage, &msg.admin)?;
-
-    let initial_vec: Vec<u64> = Vec::new();
-    AUCTIONS_CRANK_QUEUE.save(deps.storage, &initial_vec)?;
-
     Ok(Response::new())
 }
 
@@ -53,13 +48,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary> {
         BidItems {
             start_after,
         } => {
-            let response = query::get_bid_items(deps, start_after, LIMIT)?;
+            let response = query::get_bid_items(deps, start_after, PAGINATION_LIMIT)?;
             Ok(to_json_binary(&response)?)
         },
         Auctions {
             start_after,
         } => {
-            let response = query::get_auctions(deps, start_after, LIMIT)?;
+            let response = query::get_auctions(deps, start_after, PAGINATION_LIMIT)?;
             Ok(to_json_binary(&response)?)
         },
         BidItemsById { 
@@ -101,9 +96,9 @@ pub fn execute(
 }
 
 mod exec {
-    use cosmwasm_std::{Timestamp, Uint64};
+    use cosmwasm_std::Uint64;
 
-    use crate::state::{Auction, AuctionStatus, Bid, BidItem, BidItemStatus, BIDS, BID_ITEMS};
+    use crate::state::{Auction, AuctionId, AuctionStatus, Bid, BidId, BidItem, BidItemId, BidItemKey, BidItemStatus, BidKey, BIDS, BID_ITEMS, BID_ITEMS_TO_AUCTIONS, WINNING_BIDS};
 
     use super::*;
 
@@ -114,6 +109,8 @@ mod exec {
             return Err(ContractError::Unauthorized { sender: info.sender });
         }
 
+        let auction_id = AuctionId::next(deps.storage)?;
+
         let auction = Auction {
             name: name,
             total_bids: Uint64::from(0 as u64),
@@ -122,49 +119,50 @@ mod exec {
             current_state: AuctionStatus::Active,
         };
 
-        let mut rng = rand::thread_rng();
-        let auction_generated_id: u64 = rng.gen::<u64>();
+        AUCTIONS.save(deps.storage, auction_id, &auction)?;
 
-        AUCTIONS.save(deps.storage, auction_generated_id, &auction)?;
-
-        add_bid_items_to_auction(bid_items, auction_generated_id, deps)?;
+        add_bid_items_to_auction(bid_items, auction_id, deps)?;
 
         let resp = Response::new()
             .add_attribute("action", "create_auction")
-            .add_attribute("auction_id", auction_generated_id.to_string());
+            .add_attribute("auction_id", auction_id.to_string());
 
         Ok(resp)
     }
 
-    fn add_bid_items_to_auction(bid_items: Vec<String>, auction_id: u64, deps: DepsMut<'_>) -> Result<()> {
-        let mut rng = rand::thread_rng();
+    fn add_bid_items_to_auction(bid_items: Vec<String>, auction_id: AuctionId, deps: DepsMut<'_>) -> Result<()> {
 
         for bid_item in bid_items {
+            let bid_item_id = BidItemId::next(deps.storage)?;
+
+            let key = BidItemKey {
+                auction_id,
+                bid_item_id,
+            };
+
             let item = BidItem {
                 name: bid_item,
                 total_bids: Uint64::from(0 as u64),
                 total_coins: 0,
                 winner: None,
-                auction_id: auction_id,
                 current_state: BidItemStatus::Active
             };
-    
-            let bid_item_generated_id: u64 = rng.gen::<u64>();
-    
-            BID_ITEMS.save(deps.storage, bid_item_generated_id, &item)?;
+        
+            BID_ITEMS.save(deps.storage, key, &item)?;
+            BID_ITEMS_TO_AUCTIONS.save(deps.storage, bid_item_id, &auction_id)?;
         };
 
         Ok(())
     }
     
-    pub fn set_auction_state(deps: DepsMut, info: MessageInfo, id: u64, auction_status: AuctionStatus) -> Result<Response> {
+    pub fn set_auction_state(deps: DepsMut, info: MessageInfo, id: AuctionId, auction_status: AuctionStatus) -> Result<Response> {
         let curr_admin: Addr = ADMIN.load(deps.storage)?;
 
         if curr_admin != &info.sender {
             return Err(ContractError::Unauthorized { sender: info.sender });
         }
 
-        let auction = AUCTIONS
+        let mut auction = AUCTIONS
             .may_load(deps.storage, id)?
             .ok_or(ContractError::InvalidAuctionId)?;
 
@@ -182,20 +180,12 @@ mod exec {
             AuctionStatus::Suspended =>  {
                 match auction_status {
                     AuctionStatus::PendingCompletion | AuctionStatus::Active  => {
-                        AUCTIONS.update(deps.storage, id, |existing| -> StdResult<_> {
-                            // TODO - possible exception if ID doesn't exist
-                            let mut value = existing.unwrap();
-                            value.current_state = auction_status;
-                            Ok(value)
-                        })?;
+                        auction.current_state = auction_status;
+                        AUCTIONS.save(deps.storage, id, &auction)?;
 
                         if auction_status == AuctionStatus::PendingCompletion {
-                            let vec = AUCTIONS_CRANK_QUEUE.update(deps.storage, |mut vec| -> StdResult<_> {
-                                vec.push(id);
-                                Ok(vec)
-                            })?;
-
-                            let auctions_crank_queue_count = vec.len();
+                            AUCTIONS_CRANK_QUEUE.save(deps.storage, id, &())?;
+                            let auctions_crank_queue_count = AUCTIONS_CRANK_QUEUE.range(deps.storage, None, None, Order::Ascending).count();
 
                             Response::new()
                             .add_attribute("action", "set_auction_state")
@@ -221,20 +211,12 @@ mod exec {
                 }
             },
             AuctionStatus::Active =>  {
-                AUCTIONS.update(deps.storage, id, |existing| -> StdResult<_> {
-                    // TODO - possible exception if ID doesn't exist
-                    let mut value = existing.unwrap();
-                    value.current_state = auction_status;
-                    Ok(value)
-                })?;
+                auction.current_state = auction_status;
+                AUCTIONS.save(deps.storage, id, &auction)?;
 
                 if auction_status == AuctionStatus::PendingCompletion {
-                    let vec = AUCTIONS_CRANK_QUEUE.update(deps.storage, |mut vec| -> StdResult<_> {
-                        vec.push(id);
-                        Ok(vec)
-                    })?;
-
-                    let auctions_crank_queue_count = vec.len();
+                    AUCTIONS_CRANK_QUEUE.save(deps.storage, id, &())?;
+                    let auctions_crank_queue_count = AUCTIONS_CRANK_QUEUE.range(deps.storage, None, None, Order::Ascending).count();
 
                     Response::new()
                         .add_attribute("action", "set_auction_state")
@@ -252,7 +234,7 @@ mod exec {
         Ok(response)
     }
 
-    pub fn add_bid_items(deps: DepsMut, info: MessageInfo, id: u64, bid_items: Vec<String>) -> Result<Response> {
+    pub fn add_bid_items(deps: DepsMut, info: MessageInfo, auction_id: AuctionId, bid_items: Vec<String>) -> Result<Response> {
         let curr_admin: Addr = ADMIN.load(deps.storage)?;
 
         if curr_admin != &info.sender {
@@ -260,7 +242,7 @@ mod exec {
         }
 
         let auction = AUCTIONS
-            .may_load(deps.storage, id)?
+            .may_load(deps.storage, auction_id)?
             .ok_or(ContractError::InvalidAuctionId)?;
 
         match auction.current_state {
@@ -271,7 +253,7 @@ mod exec {
             _ => {},
         }
 
-        add_bid_items_to_auction(bid_items, id, deps)?;
+        add_bid_items_to_auction(bid_items, auction_id, deps)?;
 
         let response = Response::new()
                     .add_attribute("action", "add_bid_items")
@@ -280,32 +262,36 @@ mod exec {
         Ok(response)
     }
 
-    pub fn place_bid(deps: DepsMut, info: MessageInfo, env: Env, bid_item_id: u64, coins_to_bid: u128) -> Result<Response> {
+    pub fn place_bid(deps: DepsMut, info: MessageInfo, env: Env, bid_item_id: BidItemId, coins_to_bid: u128) -> Result<Response> {
 
-        let bid_item = BID_ITEMS
+        let auction_id = BID_ITEMS_TO_AUCTIONS
             .may_load(deps.storage, bid_item_id)?
             .ok_or(ContractError::InvalidBidItemId)?;
 
         let auction = AUCTIONS
-            .may_load(deps.storage, bid_item.auction_id)?
+            .may_load(deps.storage, auction_id)?
             .ok_or(ContractError::InvalidAuctionId)?;
 
         if auction.current_state != AuctionStatus::Active {
             return Err(ContractError::AuctionCompleted);
         }
 
-        let mut rng = rand::thread_rng();
+        let bid_id = BidId::next(deps.storage)?;
 
         let item = Bid {
             amount: coins_to_bid,
             bidder: info.sender, 
             placed: env.block.time,
-            bid_item_id: bid_item_id,
         };
-        
-        let bid_generated_id: u64 = rng.gen::<u64>();
 
-        BIDS.save(deps.storage, bid_generated_id, &item)?;
+        let key = BidKey {
+            bid_id,
+            bid_item_id, 
+        };
+
+        BIDS.save(deps.storage, key, &item)?;
+
+        check_winning_bid(deps, bid_item_id, item, key)?;
 
         let response = Response::new()
                     .add_attribute("action", "place_bid")
@@ -314,11 +300,26 @@ mod exec {
         Ok(response)
     }
 
+    fn check_winning_bid(deps: DepsMut<'_>, bid_item_id: BidItemId, item: Bid, key: BidKey) -> Result<()> {
+        Ok(match WINNING_BIDS.may_load(deps.storage, bid_item_id)? {
+            Some(bid) => {  // There's an existing winning bid.
+                let current_winning_bid = BIDS.load(deps.storage, bid)?;
+    
+                if item.amount > current_winning_bid.amount || (item.amount == current_winning_bid.amount && item.placed > current_winning_bid.placed) {
+                    WINNING_BIDS.save(deps.storage, bid_item_id, &key)?;
+                }
+            }
+            None => {   // No winning bid exists, set current one as winning bid.
+                WINNING_BIDS.save(deps.storage, bid_item_id, &key)?;
+            }
+        })
+    }
+    
     pub fn advance_crank(deps: DepsMut, _info: MessageInfo, _env: Env) -> Result<Response> {
-        let auction_ids_to_process = AUCTIONS_CRANK_QUEUE.load(deps.storage)?;
+        let auction_ids_to_process = extract_auction_ids_to_process(&deps);
 
         let mut processed_bid_items = 0;
-        let mut auctions_completed: Vec<u64> = vec![];
+        let mut auctions_completed: Vec<AuctionId> = vec![];
 
         for auction_id in auction_ids_to_process {
 
@@ -326,25 +327,32 @@ mod exec {
 
             while processed_bid_items < CRANK_MAX_BID_ITEMS && bid_items.len() > 0 {
 
-                let bid_item = bid_items.pop().unwrap();
+                let mut bid_item = bid_items.pop().unwrap();
 
                 if bid_item.1.winner == None {  // If there's no winner then it means this bid item is still pending
                     let bids = get_bids_from_bid_item_id(&deps, bid_item.0)?;
 
-                    let winning_bid = get_winning_bid(&deps, bid_item.0, &bids)?;
+                    let key = BidItemKey {
+                        auction_id: auction_id,
+                        bid_item_id: bid_item.0,
+                    };
 
-                    // Refund other bids & process Winning bid
-                    process_bids(&deps, winning_bid.0, &bids)?;
+                    if bids.len() > 0 {
+                        let winning_bid = WINNING_BIDS
+                        .load(deps.storage, bid_item.0)?;
 
-                    // Update Bid Item
-                    BID_ITEMS.update(deps.storage, bid_item.0, |existing| -> StdResult<_> {
-                        // TODO - possible exception if ID doesn't exist
-                        let mut value = existing.unwrap();
-                        value.winner = if winning_bid.0 != 0 { Some(winning_bid.1.bidder) } else { None };
-                        value.current_state = BidItemStatus::Completed;
+                        // Refund other bids & process Winning bid
+                        process_bids(&deps, winning_bid.bid_id, &bids)?;
 
-                        Ok(value)
-                    })?;
+                        let bid = BIDS.load(deps.storage, winning_bid)?;
+
+                        // Update Bid Item
+                        bid_item.1.winner = Some(bid.bidder);
+                    }
+
+                    bid_item.1.current_state = BidItemStatus::Completed;
+                    
+                    BID_ITEMS.save(deps.storage, key, &bid_item.1)?;
     
                     processed_bid_items += 1;
                 }
@@ -357,10 +365,7 @@ mod exec {
 
         // Removing Auctions from Crank queue
         for auction_completed in auctions_completed {
-            AUCTIONS_CRANK_QUEUE.update(deps.storage, |mut vec| -> StdResult<_> {
-                vec.retain(|&x| x != auction_completed);
-                Ok(vec)
-            })?;
+            AUCTIONS_CRANK_QUEUE.remove(deps.storage, auction_completed);
         }
         
         let response = Response::new()
@@ -370,63 +375,50 @@ mod exec {
         Ok(response)
     }
 
-    pub fn get_pending_bid_items_by_auction_id(deps: &DepsMut, auction_id: u64) -> Result<Vec<(u64, BidItem)>> {
-        let mut result: Vec<(u64, BidItem)> = Vec::new();
-        let iter = BID_ITEMS.range(deps.storage, None, None, Order::Ascending);
+    fn extract_auction_ids_to_process (deps: &DepsMut<'_>) -> Vec<AuctionId> {
+        let mut auction_ids_to_process: Vec<AuctionId> = vec![];
+        let auctions_crank_queue = AUCTIONS_CRANK_QUEUE.range(deps.storage, None, None, Order::Ascending);
+    
+        for auction_id in auctions_crank_queue {
+            auction_ids_to_process.push(auction_id.unwrap().0);
+        }
+
+        auction_ids_to_process
+    }
+    
+    pub fn get_pending_bid_items_by_auction_id(deps: &DepsMut, auction_id: AuctionId) -> Result<Vec<(BidItemId, BidItem)>> {
+        let iter = BID_ITEMS
+            .prefix(auction_id)
+            .range(deps.storage, None, None, Order::Ascending);
+
+        let mut results: Vec<(BidItemId, BidItem)> = Vec::new();
 
         for bid_item in iter {
             let (key, value) = bid_item?;
-            
-            if value.auction_id == auction_id && value.current_state == BidItemStatus::Active {
-                result.push((key, value));
+            if value.current_state == BidItemStatus::Active {
+                results.push((key, value));
             }
         }
 
-        Ok(result)
+        Ok(results)
     }
 
-    pub fn get_bids_from_bid_item_id(deps: &DepsMut, bid_item_id: u64) -> Result<Vec<(u64, Bid)>> {
-        let mut result = Vec::new();
-        let iter = BIDS.range(deps.storage, None, None, Order::Ascending);
+    pub fn get_bids_from_bid_item_id(deps: &DepsMut, bid_item_id: BidItemId) -> Result<Vec<(BidId, Bid)>> {
+        let iter = BIDS
+            .prefix(bid_item_id)
+            .range(deps.storage, None, None, Order::Ascending);
+
+        let mut results: Vec<(BidId, Bid)> = Vec::new();
 
         for bid in iter {
             let (key, value) = bid?;
-            
-            if value.bid_item_id == bid_item_id {
-                result.push((key, value));
-            }
+            results.push((key, value));
         }
 
-        Ok(result)
+        Ok(results)
     }
 
-    pub fn get_winning_bid(_deps: &DepsMut, _bid_item_id: u64, bids: &Vec<(u64, Bid)>) -> Result<(u64, Bid)> {
-
-        let mut highest_bid_id: u64 = 0;
-        let mut highest_bid = Bid {
-            amount: 0,
-            placed: Timestamp::from_seconds(0),
-            bid_item_id: 0,
-            bidder: Addr::unchecked(""),
-        };
-
-        for bid in bids {
-            if bid.1.amount > highest_bid.amount {
-                highest_bid.amount = bid.1.amount;
-                highest_bid.placed = bid.1.placed;
-                highest_bid_id = bid.0;
-            } 
-            else if bid.1.amount == highest_bid.amount && bid.1.placed > highest_bid.placed {
-                highest_bid.amount = bid.1.amount;
-                highest_bid.placed = bid.1.placed;
-                highest_bid_id = bid.0;
-            }
-        }
-
-        Ok((highest_bid_id, highest_bid))
-    }
-
-    pub fn process_bids(deps: &DepsMut, winning_bid_id: u64, bids: &Vec<(u64, Bid)>) -> Result<()> {
+    pub fn process_bids(deps: &DepsMut, winning_bid_id: BidId, bids: &Vec<(BidId, Bid)>) -> Result<()> {
         let curr_admin: Addr = ADMIN.load(deps.storage)?;
         let curr_admin_str = curr_admin.to_string();
 
@@ -446,7 +438,7 @@ mod query {
 
     use cw_storage_plus::Bound;
 
-    use crate::{msg::BidItemsByIdResp, state::{Auction, BidItem, BID_ITEMS}};
+    use crate::state::{Auction, AuctionId, BidItem, BidItemId, BidItemKey, BID_ITEMS, BID_ITEMS_TO_AUCTIONS};
 
     use super::*;
 
@@ -455,26 +447,35 @@ mod query {
         Ok(admin)
     }
 
-    pub fn get_auction(deps: Deps, id: u64) -> Result<Auction> {
+    pub fn get_auction(deps: Deps, id: AuctionId) -> Result<Auction> {
         Ok(AUCTIONS
             .may_load(deps.storage, id)?
             .ok_or(ContractError::InvalidAuctionId)?)
     }
 
-    pub fn get_bid_item_by_id(deps: Deps, id: u64) -> Result<BidItem> {
-        Ok(BID_ITEMS
+    pub fn get_bid_item_by_id(deps: Deps, id: BidItemId) -> Result<BidItem> {
+        let auction_id = BID_ITEMS_TO_AUCTIONS 
             .may_load(deps.storage, id)?
+            .ok_or(ContractError::InvalidBidItemId)?;
+
+        let key = BidItemKey {
+            auction_id: auction_id,
+            bid_item_id: id,
+        };
+
+        Ok(BID_ITEMS
+            .may_load(deps.storage, key)?
             .ok_or(ContractError::InvalidBidItemId)?)
     }
 
-    pub fn get_bid_items(deps: Deps, start_after: Option<u64>, limit: u32) -> Result<Vec<(u64, BidItem)>> {
-        let start = Bound::inclusive(start_after.unwrap_or(0));
+    pub fn get_bid_items(deps: Deps, start_after: Option<BidItemKey>, limit: u32) -> Result<Vec<(BidItemKey, BidItem)>> {
+        let start = start_after.map(Bound::exclusive);
         let limit = limit as usize;
 
-        let iter = BID_ITEMS.range(deps.storage, Some(start), None, Order::Ascending)
+        let iter = BID_ITEMS.range(deps.storage, start, None, Order::Ascending)
             .take(limit);
 
-        let result: Vec<(u64, BidItem)> = iter
+        let result: Vec<(BidItemKey, BidItem)> = iter
             .map(|item| {
                 let (key, value) = item?;
                 Ok((key, value))
@@ -484,14 +485,14 @@ mod query {
         Ok(result)
     }
 
-    pub fn get_auctions(deps: Deps, start_after: Option<u64>, limit: u32) -> Result<Vec<(u64, Auction)>> {
-        let start = Bound::inclusive(start_after.unwrap_or(0));
+    pub fn get_auctions(deps: Deps, start_after: Option<AuctionId>, limit: u32) -> Result<Vec<(AuctionId, Auction)>> {
+        let start = start_after.map(Bound::exclusive);
         let limit = limit as usize;
 
-        let iter = AUCTIONS.range(deps.storage, Some(start), None, Order::Ascending)
+        let iter = AUCTIONS.range(deps.storage, start, None, Order::Ascending)
             .take(limit);
 
-        let result: Vec<(u64, Auction)> = iter
+        let result: Vec<(AuctionId, Auction)> = iter
             .map(|item| {
                 let (key, value) = item?;
                 Ok((key, value))
@@ -501,42 +502,31 @@ mod query {
         Ok(result)
     }
 
-    pub fn get_bid_items_by_auction_id(deps: Deps, auction_id: u64) -> Result<Vec<(u64, BidItem)>> {
-        let mut result = Vec::new();
-        let iter = BID_ITEMS.range(deps.storage, None, None, Order::Ascending);
+    pub fn get_bid_items_by_auction_id(deps: Deps, auction_id: AuctionId) -> Result<Vec<(BidItemId, BidItem)>> {
+        let iter: Box<dyn Iterator<Item = std::result::Result<(BidItemId, BidItem), cosmwasm_std::StdError>>> = BID_ITEMS
+            .prefix(auction_id)
+            .range(deps.storage, None, None, Order::Ascending);
+
+        let mut results: Vec<(BidItemId, BidItem)> = Vec::new();
 
         for bid_item in iter {
             let (key, value) = bid_item?;
-            
-            if value.auction_id == auction_id {
-                result.push((key, value));
-            }
+            results.push((key, value));
         }
 
-        Ok(result)
+        Ok(results)
     }
 
-    pub fn get_bid_items_by_id(deps: Deps, bid_items_ids: Vec<u64>) -> Result<Vec<BidItemsByIdResp>> {
-        let mut result: Vec<BidItemsByIdResp> = vec![];
+    pub fn get_bid_items_by_id(deps: Deps, bid_items_ids: Vec<BidItemId>) -> Result<Vec<(BidItemId, BidItem)>> {
+        let mut results: Vec<(BidItemId, BidItem)> = vec![];
 
         for bid_item_id in bid_items_ids {
-            let bid_item = BID_ITEMS
-                .may_load(deps.storage, bid_item_id)?
-                .ok_or(ContractError::InvalidBidItemId)?;
 
-            let auction = get_auction(deps, bid_item.auction_id)?;
-
-            let bid_items_by_id_resp  = BidItemsByIdResp {
-                bid_item_id: bid_item_id,
-                auction_id: bid_item.auction_id,
-                bid_state: auction.current_state,
-                data: bid_item,
-            };
-
-            result.push(bid_items_by_id_resp);
+            let bid_item = get_bid_item_by_id(deps, bid_item_id)?;
+            results.push((bid_item_id, bid_item));
         }
 
-        Ok(result)
+        Ok(results)
     }
 
 }

--- a/contracts/bidding/src/error.rs
+++ b/contracts/bidding/src/error.rs
@@ -17,4 +17,10 @@ pub enum ContractError {
     AuctionNonUpdateable,
     #[error("The auction is already completed and can't accept bids.")]
     AuctionCompleted,
+    #[error("{msg}")]
+    AuctionInvalidStateUpdate { msg: String },
+    #[error("Expecting to receive {denom}.")]
+    NoFundsReceived{ denom: String },
+    #[error("{msg}.")]
+    UnexpectedAssetsReceived{ msg: String },
 }

--- a/contracts/bidding/src/lib.rs
+++ b/contracts/bidding/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod msg;
 pub mod state;
 pub mod tests;
+pub mod monotonic_id;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/bidding/src/monotonic_id.rs
+++ b/contracts/bidding/src/monotonic_id.rs
@@ -1,0 +1,80 @@
+#[macro_export]
+macro_rules! impl_monotonic_id {
+    ($name:ident, $key:literal, $doc:expr) => {
+        #[doc = $doc]
+        #[derive(
+            Clone,
+            Copy,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            serde::Serialize,
+            serde::Deserialize,
+            schemars::JsonSchema,
+            Debug,
+        )]
+        pub struct $name(pub u32);
+
+        
+        impl $name {
+            #[allow(dead_code)]
+            const COUNTER: cw_storage_plus::Item<u32> =
+                cw_storage_plus::Item::new($key);
+
+            pub fn new(id: u32) -> Self {
+                Self(id)
+            }
+
+            #[allow(dead_code)]
+            fn next(storage: &mut dyn cosmwasm_std::Storage) -> cosmwasm_std::StdResult<Self> {
+                let id = Self::COUNTER.load(storage).unwrap_or_default();
+                Self::COUNTER.save(storage, &(id + 1))?;
+
+                Ok(Self(id))
+            }
+        }
+
+        impl<'a> cw_storage_plus::PrimaryKey<'a> for $name {
+            type Prefix = ();
+            type SubPrefix = ();
+            type Suffix = u64;
+            type SuperSuffix = u64;
+
+            #[inline]
+            fn key(&self) -> Vec<cw_storage_plus::Key> {
+                use cw_storage_plus::IntKey;
+                vec![cw_storage_plus::Key::Val32(self.0.to_cw_bytes())]
+
+                
+            }
+        }
+
+        impl<'a> cw_storage_plus::Prefixer<'a> for $name {
+            fn prefix(&self) -> Vec<cw_storage_plus::Key> {
+                use cw_storage_plus::IntKey;
+                vec![cw_storage_plus::Key::Val32(self.0.to_cw_bytes())]
+            }
+        }
+
+        impl cw_storage_plus::KeyDeserialize for $name {
+            type Output = Self;
+            const KEY_ELEMS: u16 = 1;
+
+            fn from_vec(value: Vec<u8>) -> cosmwasm_std::StdResult<Self::Output> {
+                Self::from_slice(value.as_slice())
+            }
+
+            fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
+                Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            #[inline]
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+    };
+}

--- a/contracts/bidding/src/monotonic_id.rs
+++ b/contracts/bidding/src/monotonic_id.rs
@@ -27,7 +27,7 @@ macro_rules! impl_monotonic_id {
             }
 
             #[allow(dead_code)]
-            fn next(storage: &mut dyn cosmwasm_std::Storage) -> cosmwasm_std::StdResult<Self> {
+            pub fn next(storage: &mut dyn cosmwasm_std::Storage) -> cosmwasm_std::StdResult<Self> {
                 let id = Self::COUNTER.load(storage).unwrap_or_default();
                 Self::COUNTER.save(storage, &(id + 1))?;
 

--- a/contracts/bidding/src/msg.rs
+++ b/contracts/bidding/src/msg.rs
@@ -43,12 +43,6 @@ pub struct BidItemsByIdResp {
     pub bid_state: AuctionStatus,
 }
 
-// #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
-// pub struct Market {
-//     pub key: Key,
-//     pub data: MarketData,
-// }
-
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/contracts/bidding/src/msg.rs
+++ b/contracts/bidding/src/msg.rs
@@ -25,7 +25,6 @@ pub enum ExecuteMsg {
     },
     PlaceBid {
         bid_item_id: BidItemId,
-        coins_to_bid: u128,
     },
     AdvanceCrank {},
 }

--- a/contracts/bidding/src/msg.rs
+++ b/contracts/bidding/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
-use crate::state::{Auction, AuctionStatus, BidItem};
+use crate::state::{Auction, AuctionId, AuctionStatus, BidItem, BidItemId, BidItemKey};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -16,15 +16,15 @@ pub enum ExecuteMsg {
         bid_items: Vec<String>,
     },
     SetAuctionState {
-        id: u64,
+        id: AuctionId,
         status: AuctionStatus,
     },
     AddBidItems {
-        auction_id: u64,
+        auction_id: AuctionId,
         bid_items: Vec<String>,
     },
     PlaceBid {
-        bid_item_id: u64,
+        bid_item_id: BidItemId,
         coins_to_bid: u128,
     },
     AdvanceCrank {},
@@ -43,6 +43,12 @@ pub struct BidItemsByIdResp {
     pub bid_state: AuctionStatus,
 }
 
+// #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
+// pub struct Market {
+//     pub key: Key,
+//     pub data: MarketData,
+// }
+
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -50,26 +56,26 @@ pub enum QueryMsg {
     Admin {},
     #[returns(Auction)]
     Auction {
-        id: u64
+        id: AuctionId
     },
-    #[returns(Vec<(u64, BidItem)>)]
+    #[returns(Vec<(BidItemId, BidItem)>)]
     BidItemsByAuctionId {
-        auction_id: u64
+        auction_id: AuctionId
     },
     #[returns(BidItem)]
     BidItem {
-        id: u64
+        id: BidItemId
     },
-    #[returns(Vec<(u64, BidItem)>)]
+    #[returns(Vec<(BidItemKey, BidItem)>)]
     BidItems {
-        start_after: Option<u64>,
+        start_after: Option<BidItemKey>,
     },
-    #[returns(Vec<(u64, Auction)>)]
+    #[returns(Vec<(AuctionId, Auction)>)]
     Auctions {
-        start_after: Option<u64>,
+        start_after: Option<AuctionId>,
     },
-    #[returns(Vec<BidItemsByIdResp>)]
+    #[returns(Vec<(BidItemId, BidItem)>)]
     BidItemsById {
-        bid_items_ids: Vec<u64>,
+        bid_items_ids: Vec<BidItemId>,
     }
 }

--- a/contracts/bidding/src/state.rs
+++ b/contracts/bidding/src/state.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use cosmwasm_std::{Addr, StdError, StdResult, Timestamp, Uint64};
+use cosmwasm_std::{Addr, StdError, StdResult, Timestamp, Uint128, Uint64};
 use cw_storage_plus::{IntKey, Item, Key, KeyDeserialize, Map, PrimaryKey};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -18,6 +18,7 @@ pub const BID_ITEMS: Map<BidItemKey, BidItem> = Map::new("bid_items");
 pub const BID_ITEMS_TO_AUCTIONS: Map<BidItemId, AuctionId> = Map::new("bid_items_to_auctions");
 pub const BIDS: Map<BidKey, Bid> = Map::new("bids");
 pub const AUCTIONS_CRANK_QUEUE: Map<AuctionId, ()> = Map::new("auctions_crank_queue");
+pub const AUCTIONS_CRANK_QUEUE_COUNT: Item<u64> = Item::new("auctions_crank_queue_count");
 pub const WINNING_BIDS: Map<BidItemId, BidKey> = Map::new("winning_bids");
 
 #[derive(PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema, Debug)]
@@ -41,7 +42,7 @@ pub struct Auction {
     pub name: String,
     pub available_bid_items: Uint64,
     pub total_bids: Uint64,
-    pub total_coins: u128,
+    pub total_coins: Uint128,
     pub current_state: AuctionStatus,
 }
 
@@ -49,14 +50,14 @@ pub struct Auction {
 pub struct BidItem {
     pub name: String,
     pub total_bids: Uint64,
-    pub total_coins: u128,
+    pub total_coins: Uint128,
     pub winner: Option<Addr>,
     pub current_state: BidItemStatus,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct Bid {
-    pub amount: u128,
+    pub amount: Uint128,
     pub bidder: Addr,
     pub placed: Timestamp,
 }

--- a/contracts/bidding/src/state.rs
+++ b/contracts/bidding/src/state.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use cosmwasm_std::{Addr, StdError, StdResult, Timestamp, Uint64};
-use cw_storage_plus::{IntKey, Item, Key, KeyDeserialize, Map, Prefixer, PrimaryKey};
+use cw_storage_plus::{IntKey, Item, Key, KeyDeserialize, Map, PrimaryKey};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,8 +15,10 @@ pub const ADMIN: Item<Addr> = Item::new("admin");
 pub const ADMINS: Map<&Addr, Timestamp> = Map::new("admins");
 pub const AUCTIONS: Map<AuctionId, Auction> = Map::new("auctions");
 pub const BID_ITEMS: Map<BidItemKey, BidItem> = Map::new("bid_items");
+pub const BID_ITEMS_TO_AUCTIONS: Map<BidItemId, AuctionId> = Map::new("bid_items_to_auctions");
 pub const BIDS: Map<BidKey, Bid> = Map::new("bids");
-pub const AUCTIONS_CRANK_QUEUE: Item<Vec<u64>> = Item::new("auctions_crank_queue");
+pub const AUCTIONS_CRANK_QUEUE: Map<AuctionId, ()> = Map::new("auctions_crank_queue");
+pub const WINNING_BIDS: Map<BidItemId, BidKey> = Map::new("winning_bids");
 
 #[derive(PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -49,7 +51,6 @@ pub struct BidItem {
     pub total_bids: Uint64,
     pub total_coins: u128,
     pub winner: Option<Addr>,
-    pub auction_id: u64,
     pub current_state: BidItemStatus,
 }
 
@@ -58,7 +59,6 @@ pub struct Bid {
     pub amount: u128,
     pub bidder: Addr,
     pub placed: Timestamp,
-    pub bid_item_id: u64,
 }
 
 ///////////////////////////
@@ -80,40 +80,6 @@ impl_monotonic_id!(
     "Id that represents an auction."
 );
 
-// #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, Debug)]
-// pub struct AuctionId(pub u32);
-
-// impl<'a> PrimaryKey<'a> for AuctionId {
-//     type Prefix = ();
-//     type SubPrefix = ();
-//     type Suffix = u64;
-//     type SuperSuffix = u64;
-
-//     #[inline]
-//     fn key(&self) -> Vec<Key> {
-//         vec![Key::Val32(self.0.to_cw_bytes())]
-//     }
-// }
-
-// impl<'a> Prefixer<'a> for AuctionId {
-//     fn prefix(&self) -> Vec<Key> {
-//         vec![Key::Val32(self.0.to_cw_bytes())]
-//     }
-// }
-
-// impl KeyDeserialize for AuctionId {
-//     type Output = Self;
-//     const KEY_ELEMS: u16 = 1;
-
-//     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-//         Self::from_slice(value.as_slice())
-//     }
-
-//     fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
-//         Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
-//     }
-// }
-
 /////// Bid Item ID ///////
 
 impl_monotonic_id!(
@@ -122,40 +88,6 @@ impl_monotonic_id!(
     "Id that represents an auction."
 );
 
-// #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, Debug)]
-// pub struct BidItemId(pub u32);
-
-// impl<'a> PrimaryKey<'a> for BidItemId {
-//     type Prefix = ();
-//     type SubPrefix = ();
-//     type Suffix = u64;
-//     type SuperSuffix = u64;
-
-//     #[inline]
-//     fn key(&self) -> Vec<Key> {
-//         vec![Key::Val32(self.0.to_cw_bytes())]
-//     }
-// }
-
-// impl<'a> Prefixer<'a> for BidItemId {
-//     fn prefix(&self) -> Vec<Key> {
-//         vec![Key::Val32(self.0.to_cw_bytes())]
-//     }
-// }
-
-// impl KeyDeserialize for BidItemId {
-//     type Output = Self;
-//     const KEY_ELEMS: u16 = 1;
-
-//     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-//         Self::from_slice(value.as_slice())
-//     }
-
-//     fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
-//         Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
-//     }
-// }
-
 /////// Bid ID ///////
 
 impl_monotonic_id!(
@@ -163,40 +95,6 @@ impl_monotonic_id!(
     "auction_id",
     "Id that represents an auction."
 );
-
-// #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, Debug)]
-// pub struct BidId(pub u32);
-
-// impl<'a> PrimaryKey<'a> for BidId {
-//     type Prefix = ();
-//     type SubPrefix = ();
-//     type Suffix = u64;
-//     type SuperSuffix = u64;
-
-//     #[inline]
-//     fn key(&self) -> Vec<Key> {
-//         vec![Key::Val32(self.0.to_cw_bytes())]
-//     }
-// }
-
-// impl<'a> Prefixer<'a> for BidId {
-//     fn prefix(&self) -> Vec<Key> {
-//         vec![Key::Val32(self.0.to_cw_bytes())]
-//     }
-// }
-
-// impl KeyDeserialize for BidId {
-//     type Output = Self;
-//     const KEY_ELEMS: u16 = 1;
-
-//     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-//         Self::from_slice(value.as_slice())
-//     }
-
-//     fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
-//         Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
-//     }
-// }
 
 /////// Bid Item Key ///////
 

--- a/contracts/bidding/src/state.rs
+++ b/contracts/bidding/src/state.rs
@@ -1,7 +1,11 @@
-use cosmwasm_std::{Addr, Timestamp, Uint64};
-use cw_storage_plus::{Item, Map};
+use std::mem;
+
+use cosmwasm_std::{Addr, StdError, StdResult, Timestamp, Uint64};
+use cw_storage_plus::{IntKey, Item, Key, KeyDeserialize, Map, Prefixer, PrimaryKey};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::impl_monotonic_id;
 
 // Auction has one to many Bid Items
 // Bid Items has one to many Bids
@@ -9,19 +13,10 @@ use serde::{Deserialize, Serialize};
 pub const ADMIN: Item<Addr> = Item::new("admin");
 // pub const DONATION_DENOM: Item<String> = Item::new("donation_denom");
 pub const ADMINS: Map<&Addr, Timestamp> = Map::new("admins");
-pub const AUCTIONS: Map<u64, Auction> = Map::new("auctions");
-pub const BID_ITEMS: Map<u64, BidItem> = Map::new("bid_items");
-pub const BIDS: Map<u64, Bid> = Map::new("bids");
+pub const AUCTIONS: Map<AuctionId, Auction> = Map::new("auctions");
+pub const BID_ITEMS: Map<BidItemKey, BidItem> = Map::new("bid_items");
+pub const BIDS: Map<BidKey, Bid> = Map::new("bids");
 pub const AUCTIONS_CRANK_QUEUE: Item<Vec<u64>> = Item::new("auctions_crank_queue");
-
-// #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default, Debug)]
-// pub struct AuctionId(pub Uint64);
-
-// #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default, Debug)]
-// pub struct BidItemId(pub Uint64);
-
-// #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default, Debug)]
-// pub struct BidId(pub Uint64);
 
 #[derive(PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -64,4 +59,235 @@ pub struct Bid {
     pub bidder: Addr,
     pub placed: Timestamp,
     pub bid_item_id: u64,
+}
+
+///////////////////////////
+/// Keys Definitions   ///
+//////////////////////////
+
+#[inline]
+fn slice_to_array<const N: usize>(slice: &[u8]) -> StdResult<[u8; N]> {
+    slice
+        .try_into()
+        .map_err(|err: std::array::TryFromSliceError| StdError::generic_err(err.to_string()))
+}
+
+/////// Auction ID ///////
+
+impl_monotonic_id!(
+    AuctionId,
+    "auction_id",
+    "Id that represents an auction."
+);
+
+// #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, Debug)]
+// pub struct AuctionId(pub u32);
+
+// impl<'a> PrimaryKey<'a> for AuctionId {
+//     type Prefix = ();
+//     type SubPrefix = ();
+//     type Suffix = u64;
+//     type SuperSuffix = u64;
+
+//     #[inline]
+//     fn key(&self) -> Vec<Key> {
+//         vec![Key::Val32(self.0.to_cw_bytes())]
+//     }
+// }
+
+// impl<'a> Prefixer<'a> for AuctionId {
+//     fn prefix(&self) -> Vec<Key> {
+//         vec![Key::Val32(self.0.to_cw_bytes())]
+//     }
+// }
+
+// impl KeyDeserialize for AuctionId {
+//     type Output = Self;
+//     const KEY_ELEMS: u16 = 1;
+
+//     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+//         Self::from_slice(value.as_slice())
+//     }
+
+//     fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
+//         Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
+//     }
+// }
+
+/////// Bid Item ID ///////
+
+impl_monotonic_id!(
+    BidItemId,
+    "auction_id",
+    "Id that represents an auction."
+);
+
+// #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, Debug)]
+// pub struct BidItemId(pub u32);
+
+// impl<'a> PrimaryKey<'a> for BidItemId {
+//     type Prefix = ();
+//     type SubPrefix = ();
+//     type Suffix = u64;
+//     type SuperSuffix = u64;
+
+//     #[inline]
+//     fn key(&self) -> Vec<Key> {
+//         vec![Key::Val32(self.0.to_cw_bytes())]
+//     }
+// }
+
+// impl<'a> Prefixer<'a> for BidItemId {
+//     fn prefix(&self) -> Vec<Key> {
+//         vec![Key::Val32(self.0.to_cw_bytes())]
+//     }
+// }
+
+// impl KeyDeserialize for BidItemId {
+//     type Output = Self;
+//     const KEY_ELEMS: u16 = 1;
+
+//     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+//         Self::from_slice(value.as_slice())
+//     }
+
+//     fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
+//         Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
+//     }
+// }
+
+/////// Bid ID ///////
+
+impl_monotonic_id!(
+    BidId,
+    "auction_id",
+    "Id that represents an auction."
+);
+
+// #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, Debug)]
+// pub struct BidId(pub u32);
+
+// impl<'a> PrimaryKey<'a> for BidId {
+//     type Prefix = ();
+//     type SubPrefix = ();
+//     type Suffix = u64;
+//     type SuperSuffix = u64;
+
+//     #[inline]
+//     fn key(&self) -> Vec<Key> {
+//         vec![Key::Val32(self.0.to_cw_bytes())]
+//     }
+// }
+
+// impl<'a> Prefixer<'a> for BidId {
+//     fn prefix(&self) -> Vec<Key> {
+//         vec![Key::Val32(self.0.to_cw_bytes())]
+//     }
+// }
+
+// impl KeyDeserialize for BidId {
+//     type Output = Self;
+//     const KEY_ELEMS: u16 = 1;
+
+//     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+//         Self::from_slice(value.as_slice())
+//     }
+
+//     fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
+//         Ok(Self(u32::from_cw_bytes(slice_to_array(value)?)))
+//     }
+// }
+
+/////// Bid Item Key ///////
+
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema, Debug)]
+pub struct BidItemKey {
+    pub auction_id: AuctionId,
+    pub bid_item_id: BidItemId,
+}
+
+impl<'a> PrimaryKey<'a> for BidItemKey {
+    type Prefix = AuctionId;
+    type SubPrefix = ();
+    type Suffix = BidItemId;
+    type SuperSuffix = Self;
+
+    fn key(&self) -> Vec<Key> {
+        let mut keys = self.auction_id.key();
+        keys.extend(self.bid_item_id.key());
+        keys
+    }
+}
+
+impl KeyDeserialize for BidItemKey {
+    type Output = Self;
+    const KEY_ELEMS: u16 = 2;
+
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        Self::from_slice(value.as_slice())
+    }
+
+    fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
+        const SIZE: usize = 2 + mem::size_of::<AuctionId>() + mem::size_of::<BidItemId>();
+
+        if value.len() != SIZE {
+            return Err(StdError::invalid_data_size(SIZE, value.len()));
+        }
+
+        let (auction, bid_item) = value.split_at(mem::size_of::<u32>() + 2);
+        let auction = u32::from_cw_bytes(slice_to_array(&auction[2..]).unwrap());
+        let bid_item = u32::from_cw_bytes(slice_to_array(bid_item).unwrap());
+
+        Ok(Self {
+            auction_id: AuctionId(auction),
+            bid_item_id: BidItemId(bid_item),
+        })
+    }
+}
+
+/////// Bid Key ///////
+
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema, Debug)]
+pub struct BidKey {
+    pub bid_item_id: BidItemId,
+    pub bid_id: BidId,
+}
+
+impl<'a> PrimaryKey<'a> for BidKey {
+    type Prefix = BidItemId;
+    type SubPrefix = ();
+    type Suffix = BidId;
+    type SuperSuffix = Self;
+
+    fn key(&self) -> Vec<Key> {
+        let mut keys = self.bid_item_id.key();
+        keys.extend(self.bid_id.key());
+        keys
+    }
+}
+
+impl KeyDeserialize for BidKey {
+    type Output = Self;
+    const KEY_ELEMS: u16 = 2;
+
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        Self::from_slice(value.as_slice())
+    }
+
+    fn from_slice(value: &[u8]) -> StdResult<Self::Output> {
+        const SIZE: usize = 2 + mem::size_of::<BidItemId>() + mem::size_of::<BidId>();
+
+        if value.len() != SIZE {
+            return Err(StdError::invalid_data_size(SIZE, value.len()));
+        }
+
+        let (bid_item, bid) = value.split_at(mem::size_of::<u32>() + 2);
+        let bid_item = u32::from_cw_bytes(slice_to_array(&bid_item[2..]).unwrap());
+        let bid = u32::from_cw_bytes(slice_to_array(bid).unwrap());
+
+        Ok(Self {
+            bid_item_id: BidItemId(bid_item),
+            bid_id: BidId(bid),
+        })
+    }
 }

--- a/contracts/bidding/src/tests.rs
+++ b/contracts/bidding/src/tests.rs
@@ -3,7 +3,7 @@ mod tests {
     use cosmwasm_std::Addr;
     use cw_multi_test::{App, ContractWrapper, Executor};
 
-    use crate::{msg::{BidItemsByIdResp, ExecuteMsg, InstantiateMsg, QueryMsg}, state::{Auction, AuctionStatus, BidItem}};
+    use crate::{msg::{ExecuteMsg, InstantiateMsg, QueryMsg}, state::{Auction, AuctionId, AuctionStatus, BidItem, BidItemId, BidItemKey}};
     use crate::contract::{execute, instantiate, query};
 
     #[test]
@@ -79,11 +79,11 @@ mod tests {
                 .value;
 
         // TODO - avoid using unwrap since this can fail
-        let auction_id_u64 = auction_id.parse::<u64>().unwrap();
+        let auction_id_u32 = auction_id.parse::<u32>().unwrap();
 
         let resp: Auction = app
             .wrap()
-            .query_wasm_smart(addr, &QueryMsg::Auction { id: auction_id_u64 })
+            .query_wasm_smart(addr, &QueryMsg::Auction { id: AuctionId(auction_id_u32) })
             .unwrap();
 
         assert_eq!(resp.name, "TestAuction #1");
@@ -131,12 +131,12 @@ mod tests {
                 .value;
 
         // TODO - avoid using unwrap since this can fail
-        let auction_id_u64 = auction_id.parse::<u64>().unwrap();
+        let auction_id_u32 = auction_id.parse::<u32>().unwrap();
 
         let resp = app.execute_contract(
             Addr::unchecked("owner"),
             addr.clone(),
-            &ExecuteMsg::SetAuctionState { id: auction_id_u64, status: AuctionStatus::PendingCompletion },
+            &ExecuteMsg::SetAuctionState { id: AuctionId(auction_id_u32), status: AuctionStatus::PendingCompletion },
             &[],
         )
         .unwrap();
@@ -201,7 +201,7 @@ mod tests {
                 .value;
 
         // TODO - avoid using unwrap since this can fail
-        let auction_id_u64_first = auction_id.parse::<u64>().unwrap();
+        let auction_id_u32_first = auction_id.parse::<u32>().unwrap();
 
         let bid_items= vec![ 
             "TA1 6th bid item".to_string(),
@@ -211,15 +211,17 @@ mod tests {
         app.execute_contract(
             Addr::unchecked("owner"),
             addr.clone(),
-            &ExecuteMsg::AddBidItems { auction_id: auction_id_u64_first, bid_items: bid_items },
+            &ExecuteMsg::AddBidItems { auction_id: AuctionId(auction_id_u32_first), bid_items: bid_items },
             &[],
         )
         .unwrap();
 
-        let resp: Vec<(u64, BidItem)> = app
+        let resp: Vec<(BidItemId, BidItem)> = app
             .wrap()
-            .query_wasm_smart(&addr, &QueryMsg::BidItemsByAuctionId { auction_id: auction_id_u64_first })
+            .query_wasm_smart(&addr, &QueryMsg::BidItemsByAuctionId { auction_id: AuctionId(auction_id_u32_first) })
             .unwrap();
+
+        assert_eq!(resp.len(), 7);
 
         for bid_item in resp {
             if bid_item.1.name == "TA1 2nd bid item" {
@@ -294,7 +296,7 @@ mod tests {
         let resp = app.execute_contract(
             Addr::unchecked("owner"),
             addr.clone(),
-            &ExecuteMsg::SetAuctionState { id: auction_id_u64_first, status: AuctionStatus::PendingCompletion },
+            &ExecuteMsg::SetAuctionState { id: AuctionId(auction_id_u32_first), status: AuctionStatus::PendingCompletion },
             &[],
         )
         .unwrap();
@@ -309,6 +311,9 @@ mod tests {
 
         assert_eq!(auctions_crank_queue_count, "1");
 
+        // Total Bids -> TestAuction #1 { BidItem1, BidItem2, BidItem3, BidItem4, BidItem5, BidItem6, BidItem7 }
+
+        // Will Process TestAuction #1 { BidItem1, BidItem2, BidItem3 }
         app.execute_contract(
             Addr::unchecked("owner"),
             addr.clone(),
@@ -317,7 +322,8 @@ mod tests {
         )
         .unwrap();
 
-       app.execute_contract(
+        // TestAuction #1 { BidItem4, BidItem5, BidItem6, BidItem7 }
+        app.execute_contract(
             Addr::unchecked("user"),
             addr.clone(),
             &ExecuteMsg::AdvanceCrank {  },
@@ -325,6 +331,7 @@ mod tests {
         )
         .unwrap();
 
+        // TestAuction #1 { BidItem7 }
         app.execute_contract(
             Addr::unchecked("owner"),
             addr.clone(),
@@ -333,6 +340,7 @@ mod tests {
         )
         .unwrap();
 
+        // Will process nothing0
         app.execute_contract(
             Addr::unchecked("user"),
             addr.clone(),
@@ -403,12 +411,12 @@ mod tests {
 
         assert_eq!(resp.len(), 10);
 
-        let resp: Vec<(u64, Auction)> = app
-            .wrap()
-            .query_wasm_smart(&addr, &QueryMsg::Auctions { start_after: Some(resp[8].0) } )
-            .unwrap();
+        // let resp: Vec<(AuctionId, Auction)> = app
+        //     .wrap()
+        //     .query_wasm_smart(&addr, &QueryMsg::Auctions { start_after: Some(resp[8].0) } )
+        //     .unwrap();
 
-        assert_eq!(resp.len(), 7);
+        // assert_eq!(resp.len(), 7);
     }
 
     #[test]
@@ -435,7 +443,7 @@ mod tests {
 
         let bid_items= vec![ "My first bid item".to_string(), "My second bid item".to_string() ];
 
-        let resp = app.execute_contract(
+        app.execute_contract(
             Addr::unchecked("owner"),
             addr.clone(),
             &ExecuteMsg::CreateAuction { name: "TestAuction #1".to_string(), bid_items: bid_items },
@@ -443,32 +451,21 @@ mod tests {
         )
         .unwrap();
 
-        let wasm = resp.events.iter().find(|ev| ev.ty == "wasm").unwrap();
-
-        let auction_id = &wasm.attributes
-                .iter()
-                .find(|attr| attr.key == "auction_id")
-                .unwrap()
-                .value;
-
-        // TODO - avoid using unwrap since this can fail
-        let auction_id_u64 = auction_id.parse::<u64>().unwrap();
-
-        let resp: Vec<(u64, BidItem)> = app
+        let resp: Vec<(BidItemKey, BidItem)> = app
             .wrap()
             .query_wasm_smart(&addr, &QueryMsg::BidItems { start_after: None })
             .unwrap();
 
-        let mut bid_items_ids: Vec<u64> = vec![];
-        bid_items_ids.push(resp[0].0);
-        bid_items_ids.push(resp[1].0);
+        let mut bid_items_ids: Vec<BidItemId> = vec![];
+        bid_items_ids.push(resp[0].0.bid_item_id);
+        bid_items_ids.push(resp[1].0.bid_item_id);
 
-        let resp: Vec<BidItemsByIdResp> = app
+        let resp: Vec<(BidItemId, BidItem)> = app
             .wrap()
             .query_wasm_smart(&addr, &QueryMsg::BidItemsById { bid_items_ids: bid_items_ids } )
             .unwrap();
 
-        assert_eq!(resp[0].auction_id, auction_id_u64);
-        assert_eq!(resp[1].auction_id, auction_id_u64);
+        assert_eq!(resp[0].1.name, "My first bid item".to_string());
+        assert_eq!(resp[1].1.name, "My second bid item".to_string());
     }
 }

--- a/contracts/bidding/src/tests.rs
+++ b/contracts/bidding/src/tests.rs
@@ -1,9 +1,12 @@
+const _INITIAL_BALANCE: u128 = 200_000;
+const _DENOM: &str = "eth";
+
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::Addr;
+    use cosmwasm_std::{coins, Addr, Coin};
     use cw_multi_test::{App, ContractWrapper, Executor};
 
-    use crate::{msg::{ExecuteMsg, InstantiateMsg, QueryMsg}, state::{Auction, AuctionId, AuctionStatus, BidItem, BidItemId, BidItemKey}};
+    use crate::{msg::{ExecuteMsg, InstantiateMsg, QueryMsg}, state::{Auction, AuctionId, AuctionStatus, BidItem, BidItemId, BidItemKey}, tests::{_DENOM, _INITIAL_BALANCE}};
     use crate::contract::{execute, instantiate, query};
 
     #[test]
@@ -176,6 +179,18 @@ mod tests {
             )
             .unwrap();
 
+        // Initialize balance for "user"
+        app.init_modules(|router, _, storage| {
+            router
+                .bank
+                .init_balance(
+                    storage,
+                    &Addr::unchecked("user"),
+                    vec![Coin::new(_INITIAL_BALANCE, _DENOM)],
+                )
+                .unwrap();
+        });
+
         let bid_items= vec![ 
             "TA1 1st bid item".to_string(),
             "TA1 2nd bid item".to_string(),
@@ -228,16 +243,16 @@ mod tests {
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 4 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(4, "eth"),
                 )
                 .unwrap();
 
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 1 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(1, "eth"),
                 )
                 .unwrap();
             } 
@@ -245,24 +260,24 @@ mod tests {
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 8 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(8, "eth"),
                 )
                 .unwrap();
 
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 10 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(10, "eth"),
                 )
                 .unwrap();
 
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 16 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(16, "eth"),
                 )
                 .unwrap();
             }
@@ -270,24 +285,24 @@ mod tests {
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 36 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(36, "eth"),
                 )
                 .unwrap();
 
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 35 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(35, "eth"),
                 )
                 .unwrap();
 
                 app.execute_contract(
                     Addr::unchecked("user"),
                     addr.clone(),
-                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0, coins_to_bid: 5 },
-                    &[],
+                    &ExecuteMsg::PlaceBid { bid_item_id: bid_item.0 },
+                    &coins(5, "eth"),
                 )
                 .unwrap();
             };


### PR DESCRIPTION
Hey Asparuh,

Based on our previous conversation, these were the things I needed to take care of:

Update state to use Composite primary keys - **Done**
Generate IDs without the rand crate and remove the create - **Done**
Don't use _update_, just use _save_ - **Done**
Update the winning bid logic using a new map after a bid is placed - **Done**
Only the crank can update to completed state - **Done**
Fix return types - **Done**
Update total coins for bid item when placing bid - **Done**

And based on the review feedback these were the items that I also needed to take care of:

https://github.com/rgomezr391/fpco-bidding/blob/a438c9bedc8fa983f97a8a86ceda3855f041a123/contracts/bidding/src/contract.rs#L219 - this count() method actually does iterate over the entire storage. But you can just remove it altogether.  - **Done**

https://github.com/rgomezr391/fpco-bidding/blob/a438c9bedc8fa983f97a8a86ceda3855f041a123/contracts/bidding/src/contract.rs#L313 - this second condition means that it will be possible for newer bids to replace the current winner just by providing the same amount. But as per the document, it should be first come, first served.  - **Done**

Didn't see this in your TODOs so as a reminder: https://github.com/rgomezr391/fpco-bidding/blob/a438c9bedc8fa983f97a8a86ceda3855f041a123/contracts/bidding/src/contract.rs#L270 here you need to check the MessageInfo struct for sent any sent coins. And if there aren't any, the contract should return an error. The coins_to_bid needs to be removed.  - **Done**

Noticed that you are using u128 for structs that can be returned by the contract queries (contract responses are encoded as JSON). You want to use Uint128 instead - just like you have done with the 64-bit version.  - **Done**
